### PR TITLE
Performance Page UI Update

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import api, {route} from '@forge/api'
 import {getPerformanceRatingsData} from './selfPerformance';
 import { getPeerAssessedPerformanceRatings } from './peerRatedPerformance';
 import {getMotivationRatings} from './motivation';
+import { getSatisfactionRatingsData } from './satisfaction';
 
 const resolver = new Resolver();
 

--- a/src/index.js
+++ b/src/index.js
@@ -49,6 +49,11 @@ resolver.define('getMotivation', async (req) => {
     return motivationsCount;
 });
 
+resolver.define('getSatisfactionRatingsData', async (req) => {
+    const satisfactionData = await getSatisfactionRatingsData(req);
+    return satisfactionData;
+});
+
 export const getCustomFieldID = async function (data, targetProperty) {
     for (var issue of data.issues) {
         for (var fieldName in issue.fields) {

--- a/src/satisfaction.js
+++ b/src/satisfaction.js
@@ -62,7 +62,7 @@ export const getSatisfactionRatingsData = async function (req) {
 
     var issueSatisfaction = [];
     for (var issue of data.issues) {
-        if ( issue.fields[customFieldID].mySatisfactionRating ) {
+        if ( issue.fields[customFieldID] && issue.fields[customFieldID].mySatisfactionRating ) {
             issueSatisfaction.push(issue.fields[customFieldID].mySatisfactionRating);
         };
     }

--- a/static/manager-dashboard/src/Components/Performance.css
+++ b/static/manager-dashboard/src/Components/Performance.css
@@ -1,0 +1,12 @@
+.row {
+    display: flex;
+    margin-bottom: 5%;
+  }
+  
+  .column {
+    flex: 50%;
+  }
+
+  .h3-text {
+    text-align: center;
+  }

--- a/static/manager-dashboard/src/Components/Performance.css
+++ b/static/manager-dashboard/src/Components/Performance.css
@@ -5,6 +5,8 @@
   
   .column {
     flex: 50%;
+    padding-left: 0.5%;
+    padding-right: 0.5%;
   }
 
   .h3-text {

--- a/static/manager-dashboard/src/Components/Performance.js
+++ b/static/manager-dashboard/src/Components/Performance.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { invoke } from '@forge/bridge';
 import PieChart from '../shared/PieChart';
+import VerticalBarChart from '../shared/VerticalBarChart';
 import './Performance.css';
 
 function Performance() {
@@ -8,22 +9,57 @@ function Performance() {
     const [peerAssessedPerformanceData, setPeerAssessedPerformanceData] = useState(null);
     const [selfDataEmptyStatus, setSelfDataEmptyStatus] = useState(null);
     const [peerDataEmptyStatus, setPeerDataEmptyStatus] = useState(null);
+    const [satisfactionData, setSatisfactionData] = useState(null);
 
     useEffect(() => {
         invoke('getSelfAssessedPerformanceRatings', { example: 'my-invoke-variable' }).then(setSelfAssessedPerformanceData);
         invoke('getPeerAssessedPerformanceRatings', { example: 'my-invoke-variable' }).then(setPeerAssessedPerformanceData);
         invoke('getSelfDataEmptyStatus', { example: 'my-invoke-variable' }).then(setSelfDataEmptyStatus);
         invoke('getPeerDataEmptyStatus', { example: 'my-invoke-variable' }).then(setPeerDataEmptyStatus);
+        invoke('getSatisfactionRatingsData', { example: 'my-invoke-variable' }).then(setSatisfactionData);
     }, []);
 
     const performancePieChartLabels = ['Bad', 'Somewhat Bad', 'Okay', 'Somewhat Good', 'Good'];
     const selfPerformancePieChartTitle = 'Self Assessed Performance Ratings';
     const peerPerformancePieChartTitle = 'Peer Assessed Performance Ratings';
+    const performanceBarChartTitle = 'Performance Ratings';
+    const performanceSatisfactionTitle = 'Performance vs Satisfaction Ratings';
+    const performanceBarChartLabel1 = 'SELF Assessed Performance';
+    const performanceBarChartLabel2 = 'PEER Assessed Performance';
+    const satisfactionBarChartLabel = 'Satisfaction Ratings';
+    
+    const performanceBarChartDataset = [
+        {
+          label: performanceBarChartLabel1,
+          data: selfAssessedPerformanceData,
+          backgroundColor: 'rgba(255, 99, 132, 0.5)',
+        },
+        {
+          label: performanceBarChartLabel2,
+          data: peerAssessedPerformanceData,
+          backgroundColor: 'rgba(53, 162, 235, 0.5)',
+        },
+      ];
+    
+    const performanceSatisfactionDataset = [
+    {
+        label: performanceBarChartLabel1,
+        data: selfAssessedPerformanceData,
+        backgroundColor: 'rgba(255, 99, 132, 0.5)',
+    },
+    {
+        label: satisfactionBarChartLabel,
+        data: satisfactionData,
+        backgroundColor: 'rgba(53, 162, 235, 0.5)',
+    },
+    ];
     
     var selfPerformancePieChart;
     var selfPerformanceMessage;
     var peerPerformancePieChart;
     var peerPerformanceMessage;
+    var performanceBarChart;
+    var performanceStisfactionBarChart;
 
     selfPerformancePieChart = <PieChart
             labels={performancePieChartLabels}
@@ -35,6 +71,18 @@ function Performance() {
         labels={performancePieChartLabels}
         title={peerPerformancePieChartTitle}
         dataset={peerAssessedPerformanceData}
+    />;
+
+    performanceBarChart = <VerticalBarChart
+        text={performanceBarChartTitle}
+        xAxisLabels={performancePieChartLabels}
+        dataSet={performanceBarChartDataset}
+    />;
+
+    performanceStisfactionBarChart = <VerticalBarChart
+        text={performanceSatisfactionTitle}
+        xAxisLabels={performancePieChartLabels}
+        dataSet={performanceSatisfactionDataset}
     />;
 
     selfPerformanceMessage = <p>There is currently no data available to display a pie chart for SELF assessed performance ratings!</p>
@@ -55,11 +103,11 @@ function Performance() {
             <div class="row">
                 <div class="column">
                     <h3 class="h3-text">Performance Ratings</h3>
-                    {selfDataEmptyStatus ? selfPerformanceMessage : selfPerformancePieChart}
+                    {performanceBarChart}
                 </div>
                 <div class="column">
-                    <h3 class="h3-text">SELF Assessed Performance vs Satisfaction</h3>
-                    {peerDataEmptyStatus ? peerPerformanceMessage : peerPerformancePieChart}
+                    <h3 class="h3-text">SELF Assessed Performance vs Satisfaction Ratings</h3>
+                    {performanceStisfactionBarChart}
                 </div>
             </div>
             <br/>

--- a/static/manager-dashboard/src/Components/Performance.js
+++ b/static/manager-dashboard/src/Components/Performance.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { invoke } from '@forge/bridge';
 import PieChart from '../shared/PieChart';
+import './Performance.css';
 
 function Performance() {
     const [selfAssessedPerformanceData, setSelfAssessedPerformanceData] = useState(null);
@@ -41,8 +42,27 @@ function Performance() {
 
     return (
         <div>
-            {selfDataEmptyStatus ? selfPerformanceMessage : selfPerformancePieChart}
-            {peerDataEmptyStatus ? peerPerformanceMessage : peerPerformancePieChart}
+            <div class="row">
+                <div class="column">
+                    <h3 class="h3-text">SELF Assessed Performance Ratings</h3>
+                    {selfDataEmptyStatus ? selfPerformanceMessage : selfPerformancePieChart}
+                </div>
+                <div class="column">
+                    <h3 class="h3-text">PEER Assessed Performance Ratings</h3>
+                    {peerDataEmptyStatus ? peerPerformanceMessage : peerPerformancePieChart}
+                </div>
+            </div>
+            <div class="row">
+                <div class="column">
+                    <h3 class="h3-text">Performance Ratings</h3>
+                    {selfDataEmptyStatus ? selfPerformanceMessage : selfPerformancePieChart}
+                </div>
+                <div class="column">
+                    <h3 class="h3-text">SELF Assessed Performance vs Satisfaction</h3>
+                    {peerDataEmptyStatus ? peerPerformanceMessage : peerPerformancePieChart}
+                </div>
+            </div>
+            <br/>
         </div>
     );
 }


### PR DESCRIPTION
### **Implementation:**
- Updated the UI for the Performance page
- Page structure is a 2 rows, with 2 columns per row
- First row has 2 pie charts. One pie chart for self assessed performance and the other pie chart for peer assessed performance (refer to pics below)
- Second row has 2 vertical bar charts. One bar chart is for self vs peer assessed ratings and the other bar chart is for self assessed performance vs satisfaction ratings.
- Also added in a little bit of code to obtain satisfaction data, although this should be the same once this [PR](https://github.com/Motive-Metrics/motive-metrics/pull/8) is finalised.

### **Screenshots**
<img width="1193" alt="image" src="https://user-images.githubusercontent.com/80957318/192516934-20d505f1-8cdd-4142-a521-e939a789653b.png">

<img width="1177" alt="image" src="https://user-images.githubusercontent.com/80957318/192517011-5facb72b-9575-4073-af31-6474f8688caa.png">
